### PR TITLE
Fix /scrape endpoint enrichment

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -22,7 +22,7 @@ def scrape_billboard_data():
     
     if enrich:
         year = date.split("-")[0]
-        enriched = search_spotify_tracks(songs, year)
+        enriched = search_spotify_tracks(songs, year, return_urls=True)
 
         # Combine original + enriched
         combined = []

--- a/backend/app/spotify.py
+++ b/backend/app/spotify.py
@@ -19,8 +19,8 @@ sp = spotipy.Spotify(
 )
 
 
-def search_spotify_tracks(song_data, year):
-    uris = []
+def search_spotify_tracks(song_data, year, return_urls=False):
+    results_list = []
     for item in song_data:
         title = item["title"]
         artist = item["artist"]
@@ -29,12 +29,23 @@ def search_spotify_tracks(song_data, year):
             results = sp.search(q=query, type="track", limit=1)
             items = results.get("tracks", {}).get("items")
             if items:
-                uris.append(items[0]["uri"])
+                track = items[0]
+                if return_urls:
+                    results_list.append(
+                        {
+                            "track_url": track["external_urls"].get("spotify"),
+                            "artist_url": track["artists"][0]["external_urls"].get(
+                                "spotify"
+                            ),
+                        }
+                    )
+                else:
+                    results_list.append(track["uri"])
             else:
                 logging.info(f"Not found: {title} by {artist}")
         except Exception as e:
             logging.error(f"Search error for {title} by {artist}: {e}")
-    return uris
+    return results_list
 
 
 def create_playlist(


### PR DESCRIPTION
## Summary
- adjust `search_spotify_tracks` to optionally return URLs
- use the new flag in `/scrape` endpoint

## Testing
- `python -m py_compile backend/app/*.py`
- `npm test` *(fails: react-scripts not found)*
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_683f7228a2c88326b83d669e06fec356