### PR TITLE
Fix TODO comment in routes.py

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -11,7 +11,7 @@ api = Blueprint("api", __name__)
 def scrape_billboard_data():
     date = request.args.get("date")
     limit = int(request.args.get("limit", 100))
-    # TODO FIGURE OUT WHAT THIS DOES
+    # Parse ?enrich=true to include Spotify links
     enrich = request.args.get("enrich", "false").lower() == "true"
     if not date:
         return jsonify({"success": False, "message": "Date is required"}), 400


### PR DESCRIPTION
## Summary
- replace vague TODO with a comment explaining the `enrich` query parameter

## Testing
- `python3 -m py_compile backend/app/routes.py`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f742b285483269a1490891f0e7db7